### PR TITLE
update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,11 @@ requirements = {
         "setuptools<=65.0",
         "numpy==1.24.4",
         "kaldi_native_fbank",
-        "onnxruntime==1.18.0",
+        "onnxruntime>=1.17.0",
         "sentencepiece==0.2.0",
-        "soundfile==0.12.1",
+        "soundfile>=0.10.2",
         "huggingface_hub",
+        "protobuf>=3.19.6"
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ version = "v1.1.0"
 requirements = {
     "install": [
         "setuptools<=65.0",
-        "numpy==1.24.4",
+        "numpy>=1.24.4",
         "kaldi_native_fbank",
         "onnxruntime>=1.17.0",
-        "sentencepiece==0.2.0",
-        "soundfile>=0.10.2",
+        "sentencepiece>=0.2.0",
+        "soundfile>=0.12.1",
         "huggingface_hub",
         "protobuf>=3.19.6"
     ]

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ from pathlib import Path
 from setuptools import find_namespace_packages, setup
 
 dirname = Path(os.path.dirname(__file__))
-version = "v1.1.0"
+version = "1.1.0"
 
 requirements = {
     "install": [
-        "setuptools<=65.0",
+        "setuptools",
         "numpy>=1.24.4",
         "kaldi_native_fbank",
         "onnxruntime>=1.17.0",
@@ -39,7 +39,7 @@ setup(
     "with onnxruntime",
     long_description=open(os.path.join(dirname, "README.md"), encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    license="The MIT License",
+    license="MIT", # SPDX identifier
     packages=find_namespace_packages(),
     include_package_data=True,
     install_requires=install_requires,
@@ -55,7 +55,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Operating System :: POSIX :: Linux",
-        "License :: OSI Approved :: MIT License",
         "Topic :: Multimedia :: Sound/Audio :: Speech",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Hi,

This PR addresses compatibility issues caused by overly strict version pinning in setup.py, which forces downstream projects to downgrade their dependencies when installing SenseVoice-python.

Added the changes from https://github.com/shadowcz007/SenseVoice-python at the same time (it's used from https://github.com/MixLabPro/comfyui-mixlab-nodes/blob/main/requirements.txt).

Fixes
* https://github.com/lovemefan/SenseVoice-python/issues/7  
* https://github.com/lovemefan/SenseVoice-python/issues/10  

感谢您的出色工作！